### PR TITLE
Get full tree as yang2-rs DataTree

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ bindgen = "0.59.2"
 
 [dependencies]
 libc = "0.2.121"
+yang2 = "0.7"
+libyang2-sys = "0.6"
 
 [workspace]
 members = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ members = [
   "examples/notif_send",
   "examples/rpc_subscribe",
   "examples/rpc_send",
+  "examples/sr_get_data",
   "examples/sr_get_items",
   "examples/sr_set_item",
   "examples/application_changes",

--- a/build.rs
+++ b/build.rs
@@ -19,6 +19,9 @@ fn main() {
         // The input header we would like to generate
         // bindings for.
         .header("wrapper.h")
+        // lyd_node shall be provided by libyang2-sys
+        .blocklist_item("lyd_node")
+        .raw_line("use libyang2_sys::*;")
         // Tell cargo to invalidate the built crate whenever any of the
         // included header files changed.
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))

--- a/examples/sr_get_data/Cargo.toml
+++ b/examples/sr_get_data/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+authors = ["Toshiaki Takada <toshi@reze.rs>", "Florian Kauer <florian.kauer@linutronix.de>"]
+edition = "2021"
+name = "sr_get_data"
+version = "0.3.0"
+
+[dependencies]
+sysrepo = {path = "../.."}
+utils = {path = "../utils"}
+yang2 = "0.7"

--- a/examples/sr_get_data/src/main.rs
+++ b/examples/sr_get_data/src/main.rs
@@ -1,0 +1,91 @@
+//
+// Sysrepo-examples.
+//   sr_get_data
+//
+
+use std::env;
+use std::sync::Arc;
+
+use sysrepo::*;
+use yang2::context::{Context, ContextFlags};
+use yang2::data::{Data, DataFormat, DataPrinterFlags};
+
+/// Show help.
+fn print_help(program: &str) {
+    println!("Usage: {} <x-path-to-get> [running/operational]", program);
+}
+
+/// Main.
+fn main() {
+    if run() {
+        std::process::exit(0);
+    } else {
+        std::process::exit(1);
+    }
+}
+
+fn run() -> bool {
+    let args: Vec<String> = env::args().collect();
+    let program = args[0].clone();
+
+    if args.len() != 2 && args.len() != 3 {
+        print_help(&program);
+        return false;
+    }
+
+    let xpath = args[1].clone();
+    let mut ds = SrDatastore::Running;
+
+    if args.len() == 3 {
+        if args[2] == "running" {
+            ds = SrDatastore::Running;
+        } else if args[2] == "operational" {
+            ds = SrDatastore::Operational;
+        } else {
+            println!("Invalid datastore {}.", args[2]);
+            return false;
+        }
+    }
+
+    println!(
+        r#"Application will get "{}" from "{}" datastore."#,
+        xpath,
+        if ds == SrDatastore::Running {
+            "running"
+        } else {
+            "operational"
+        }
+    );
+
+    // Turn logging on.
+    log_stderr(SrLogLevel::Warn);
+
+    // Connect to sysrepo.
+    let mut sr = match SrConn::new(0) {
+        Ok(sr) => sr,
+        Err(_) => return false,
+    };
+
+    // Start session.
+    let sess = match sr.start_session(ds) {
+        Ok(sess) => sess,
+        Err(_) => return false,
+    };
+
+    // Setup libyang context.
+    let ctx = Arc::new(Context::new(ContextFlags::NO_YANGLIBRARY).expect("Failed to create context"));
+
+    // Get the data.
+    let data = sess.get_data(&ctx, &xpath, None, None, 0).expect("Failed to get data");
+
+    // Print data tree in the XML format.
+    data
+        .print_file(
+            std::io::stdout(),
+            DataFormat::XML,
+            DataPrinterFlags::WD_ALL | DataPrinterFlags::WITH_SIBLINGS,
+        )
+        .expect("Failed to print data tree");
+
+    true
+}


### PR DESCRIPTION
This series adds the possibility to get a full tree via the sr_get_data function of libsysrepo.
As discussed in https://github.com/rwestphal/yang2-rs/issues/9, the tree is returned as yang2-rs DataTree and thus it is added as dependency.