### PR TITLE
fix: ensure data is not dropped before used by sysrepo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -603,7 +603,9 @@ impl SrSession {
             Some(orig) => Some(str_to_cstring(orig)?),
             None => None,
         };
-        let origin_ptr = origin.map_or(std::ptr::null(), |orig| orig.as_ptr());
+        let origin_ptr = origin
+            .as_deref()
+            .map_or(std::ptr::null(), |orig| orig.as_ptr());
 
         let rc = unsafe { sr_set_item_str(self.sess, path.as_ptr(), value.as_ptr(), origin_ptr, opts) };
         if rc != SrError::Ok as i32 {
@@ -643,7 +645,9 @@ impl SrSession {
             Some(path) => Some(str_to_cstring(&path)?),
             None => None,
         };
-        let xpath_ptr = xpath.map_or(std::ptr::null(), |xpath| xpath.as_ptr());
+        let xpath_ptr = xpath
+            .as_deref()
+            .map_or(std::ptr::null(), |xpath| xpath.as_ptr());
         let start_time = start_time.unwrap_or(std::ptr::null_mut());
         let stop_time = stop_time.unwrap_or(std::ptr::null_mut());
 
@@ -870,7 +874,9 @@ impl SrSession {
             Some(path) => Some(str_to_cstring(&path)?),
             None => None,
         };
-        let path_ptr = path.map_or(std::ptr::null(), |path| path.as_ptr());
+        let path_ptr = path
+            .as_deref()
+            .map_or(std::ptr::null(), |path| path.as_ptr());
 
         let rc = unsafe {
             sr_module_change_subscribe(


### PR DESCRIPTION
When using `.as_ptr`  you must make sure the underlaying value is not dropped too early as described in the [CString documentation](https://doc.rust-lang.org/std/ffi/struct.CString.html#method.as_ptr).

When using `Option.map_or` the value is consumed. This can lead to a value dropped to early when used with `Cstring.as_ptr`.

For example `path.map_or(std::ptr::null(), |path| path.as_ptr());` consumes the path and path is dropped after this line, which leads to a dangling pointer. In my setup this leads to the following error:
`[ERR] Invalid character '�'[2] of expression 'P��Y�U'.`
(With Rust 1.72.0)

Only passing a reference of the Option value to the `map_or` function prevents the value of being dropped too early.

I found three cases in this library where this issue could occur and fixed all of them with this pull request.